### PR TITLE
Add GET endpoint to retrieve AI example JSON

### DIFF
--- a/springboot-modulo/README.MD
+++ b/springboot-modulo/README.MD
@@ -132,6 +132,7 @@ El módulo está protegido con **Spring Security**.
 * **PUT** `/api/calificaciones/{id}` – Actualizar
 * **DELETE** `/api/calificaciones/{id}` – Eliminar
 * **POST** `/api/calificaciones/ai` – Aplicar calificación con IA
+* **GET** `/api/calificaciones/ai/ejemplos` – Obtener ejemplos de petición y respuesta
 
 ### Criterios de Evaluación
 
@@ -274,6 +275,7 @@ Ejemplo de respuesta luego de aplicar la calificación de la IA:
 
 Puedes encontrar estos ejemplos en los archivos
 `examples/ai_ejemplo_peticion.json` y
-`examples/ai_ejemplo_respuesta.json` para utilizarlos directamente con
+`examples/ai_ejemplo_respuesta.json`, o consultarlos desde el
+endpoint `GET /api/calificaciones/ai/ejemplos` para utilizarlos directamente con
 Postman u otra herramienta de prueba.
 ```

--- a/springboot-modulo/src/main/java/com/informaticonfing/spring/springboot_modulo/controller/CalificacionController.java
+++ b/springboot-modulo/src/main/java/com/informaticonfing/spring/springboot_modulo/controller/CalificacionController.java
@@ -4,6 +4,11 @@ import com.informaticonfing.spring.springboot_modulo.dto.CalificacionRequestDTO;
 import com.informaticonfing.spring.springboot_modulo.dto.CalificacionResponseDTO;
 import com.informaticonfing.spring.springboot_modulo.service.CalificacionService;
 import com.informaticonfing.spring.springboot_modulo.dto.AiCalificacionDTO;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.core.io.ClassPathResource;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -86,5 +91,20 @@ public class CalificacionController {
     @PostMapping("/ai")
     public CalificacionResponseDTO aplicarIA(@RequestBody AiCalificacionDTO dto) {
         return service.aplicarCalificacionAI(dto);
+    }
+
+    /**
+     * Devuelve los ejemplos de petición y respuesta para el endpoint de IA.
+     * @return mapa con los JSON de ejemplo
+     */
+    @GetMapping("/ai/ejemplos")
+    public Map<String, Object> ejemplosIA() throws IOException {
+        ObjectMapper mapper = new ObjectMapper();
+        Map<String, Object> result = new HashMap<>();
+        ClassPathResource peticion = new ClassPathResource("examples/ai_ejemplo_peticion.json");
+        ClassPathResource respuesta = new ClassPathResource("examples/ai_ejemplo_respuesta.json");
+        result.put("peticion", mapper.readValue(peticion.getInputStream(), Object.class));
+        result.put("respuesta", mapper.readValue(respuesta.getInputStream(), Object.class));
+        return result;
     }
 }

--- a/springboot-modulo/src/main/resources/examples/ai_ejemplo_peticion.json
+++ b/springboot-modulo/src/main/resources/examples/ai_ejemplo_peticion.json
@@ -1,0 +1,29 @@
+{
+  "calificacionId": 1,
+  "puntajeGlobalAi": 7.0,
+  "observacionGlobalAi": "Buena exposición, con un ritmo dinámico",
+  "detalles": [
+    {
+      "criterioId": 5,
+      "puntaje": 6,
+      "slideId": 1,
+      "comentario": "Buen ritmo al comenzar, podría haber pausas en conceptos clave"
+    },
+    {
+      "criterioId": 7,
+      "puntaje": 8,
+      "slideId": 2,
+      "comentario": "Uso efectivo de ejemplos"
+    },
+    {
+      "criterioId": 10,
+      "puntaje": 5,
+      "slideId": 3,
+      "comentario": "Texto demasiado denso en este slide"
+    }
+  ],
+  "feedbacks": [
+    { "observacion": "Sigue practicando", "autor": "IA" },
+    { "observacion": "Buen uso del contacto visual", "autor": "IA" }
+  ]
+}

--- a/springboot-modulo/src/main/resources/examples/ai_ejemplo_respuesta.json
+++ b/springboot-modulo/src/main/resources/examples/ai_ejemplo_respuesta.json
@@ -1,0 +1,38 @@
+{
+  "id": 1,
+  "grabacionId": 1,
+  "usuarioId": 1,
+  "puntajeGlobal": 7.5,
+  "observacionGlobal": "Buena exposición, especialmente en la interacción con la audiencia",
+  "tipoCalificacion": "manual",
+  "parametrosIdealesId": null,
+  "detalles": [
+    {
+      "id": 1,
+      "calificacionId": 1,
+      "criterioId": 5,
+      "slideId": 1,
+      "puntaje": 7,
+      "comentario": "Ritmo controlado, buen balance entre velocidad y pausas",
+      "fragmentoAudioId": null
+    },
+    {
+      "id": 2,
+      "calificacionId": 1,
+      "criterioId": 7,
+      "slideId": 2,
+      "puntaje": 8,
+      "comentario": "Ejemplos claros y bien explicados",
+      "fragmentoAudioId": null
+    },
+    {
+      "id": 3,
+      "calificacionId": 1,
+      "criterioId": 10,
+      "slideId": 3,
+      "puntaje": 6,
+      "comentario": "Texto algo denso, tal vez resumir puntos clave",
+      "fragmentoAudioId": null
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add new endpoint `GET /api/calificaciones/ai/ejemplos` to serve AI request/response examples
- document the endpoint in README
- include example files in the JAR resources

## Testing
- `./mvnw -q test` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684779f63388832bafef9a54b5cddf86